### PR TITLE
callback functions - settingsChangedCallback and packetReceivedCallback

### DIFF
--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -28,6 +28,19 @@
 #include "WProgram.h"
 #endif
 
+/* 
+ * Callback function definitions. Code differs for the ESP8266 platform, which requires the functional library.
+ * Based on callback implementation in the Arduino Client for MQTT library (https://github.com/knolleary/pubsubclient)
+ */
+#ifdef ESP8266
+#include <functional>
+#define SETTINGS_CHANGED_CALLBACK_SIGNATURE std::function<void()> settingsChangedCallback
+#define PACKET_RECEIVED_CALLBACK_SIGNATURE std::function<void(byte* data, unsigned int length)> packetReceivedCallback
+#else
+#define SETTINGS_CHANGED_CALLBACK_SIGNATURE void (*settingsChangedCallback)();
+#define PACKET_RECEIVED_CALLBACK_SIGNATURE void (*packetReceivedCallback)(byte* data, unsigned int length);
+#endif
+
 typedef uint8_t byte;
 
 struct heatpumpSettings {
@@ -91,8 +104,11 @@ class HeatPump
     void createInfoPacket(byte *packet);
     int getData();
 
+    // callbacks
+    SETTINGS_CHANGED_CALLBACK_SIGNATURE;
+    PACKET_RECEIVED_CALLBACK_SIGNATURE;
+
   public:
-                          
     HeatPump();
     void connect(HardwareSerial *serial);
     bool update();
@@ -116,5 +132,8 @@ class HeatPump
     int getRoomTemperature();
     unsigned int FahrenheitToCelsius(unsigned int tempF);
     unsigned int CelsiusToFahrenheit(unsigned int tempC);
+
+    void setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE);
+    void setPacketReceivedCallback(PACKET_RECEIVED_CALLBACK_SIGNATURE);
 };
 #endif


### PR DESCRIPTION
Hi @SwiCago 

Thanks for merging #2! With that out of the way, I would like to slowly work through some of the other ideas for improvements (including some code doco) that I have.

This pull request is for some callback functions, to allow users of the library to code some action in their sketches whenever certain events happen in the library. The two events for callbacks I have in mind are:

- whenever the heatpump's settings are changed (for example if someone presses a button on the remote control, the sketch will be able to easily execute some code
- whenever a valid (checksum passes) packet is received from the heatpump (this one is mostly for debugging - it creates an wasy way for the user's sketch to get every packet that is received from the heatpump, without putting any debug code in the library itself.

The single commit in this pull request has:

- added two callback functions: one for when the heatpump settings change and the other (for debugging purposes) when a packet is received by the heatpump, which can be used as follows:

`void setup() {`
  `hp.setSettingsChangedCallback(hpSettingsChanged);`
  `hp.setPacketReceivedCallback(hpPacketReceived);`
`}`

`void hpSettingsChanged() {`
  `// settings have changed - do something...`
`}`

`void hpPacketReceived(byte* packet, unsigned int length) {`
  `// packet received from heatpump - do something...`
`}`

- updated mitsubishi_heatpump_mqtt_esp8266 example to use both callbacks. I will start to use this to debug other data in the packet, for example the isave mode where temperature can be set as low as 10

Please review, and I am happy to discuss more if needed :)

Thanks :)
kayno

