### PR TITLE
removed superfluous class name and Paamayim Nekudotayim from function calls

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -113,12 +113,12 @@ heatpumpSettings HeatPump::getSettings() {
 }
 
 void HeatPump::setSettings(heatpumpSettings settings) {
-  HeatPump::setPowerSetting(settings.power);
-  HeatPump::setModeSetting(settings.mode);
-  HeatPump::setTemperature(settings.temperature);
-  HeatPump::setFanSpeed(settings.fan);
-  HeatPump::setVaneSetting(settings.vane);
-  HeatPump::setWideVaneSetting(settings.wideVane);
+  setPowerSetting(settings.power);
+  setModeSetting(settings.mode);
+  setTemperature(settings.temperature);
+  setFanSpeed(settings.fan);
+  setVaneSetting(settings.vane);
+  setWideVaneSetting(settings.wideVane);
 }
 
 bool HeatPump::getPowerSettingBool() {


### PR DESCRIPTION
@SwiCago - thought I would wrap up just this change in one commit and pull request, as I figure it's better to have more small commits/merges than fewer larger ones!

RE: a public loop() function, I have been thinking about this and decided there is probably no need. I did some research and couldn't find anything that pointed to a standard practice of calling a library function "loop" if it should be called every iteration of the sketch's loop, so I think sync() is just fine. Plus it makes sense - it's keep the ESP8266 or whatever is running the library in "sync" with the heatpump. So I think it's good as is. Unless you see another reason?

I use [http://home-assistant.io](http://home-assistant.io) for controlling the heatpump and automation. I will upload my heatpump configuration file in case you are interested in trying it out. Will get you the link once I have it up on github.