### PR TITLE
sync settings during update() call, and set wantedSettings to currentSettings once known on first sync

### DIFF
--- a/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
+++ b/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
@@ -59,7 +59,7 @@ void setup() {
   hp.connect(&Serial);
   
   hp.setSettingsChangedCallback(hpSettingsChanged);
-  hp.setPacketReceivedCallback(hpPacketReceived);
+  hp.setPacketCallback(hpPacketDebug);
 }
 
 void hpSettingsChanged() {
@@ -84,7 +84,7 @@ void hpSettingsChanged() {
     mqtt_client.publish(heatpump_topic, buffer, retain);
 }
 
-void hpPacketReceived(byte* packet, unsigned int length) {
+void hpPacketDebug(byte* packet, unsigned int length, char* packetDirection) {
   if(_debugMode) {
     String message;
     for (int idx = 0; idx < length; idx++) {
@@ -99,7 +99,7 @@ void hpPacketReceived(byte* packet, unsigned int length) {
     
     JsonObject& root = jsonBuffer.createObject();
   
-    root["packet"] = message;
+    root[packetDirection] = message;
   
     char buffer[512];
     root.printTo(buffer, sizeof(buffer));

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -187,8 +187,7 @@ unsigned int HeatPump::CelsiusToFahrenheit(unsigned int tempC) {
   return currentSettings.mode == MODE_MAP[0] ? ceil(temp) : floor(temp);
 }
 
-void HeatPump::setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE, byte callbackOptions) {
-  settingsChangedCallbackOptions = callbackOptions;
+void HeatPump::setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE) {
   this->settingsChangedCallback = settingsChangedCallback;
 }
 
@@ -399,7 +398,7 @@ int HeatPump::readPacket() {
           receivedSettings.vane        = lookupByteMapValue(VANE_MAP, VANE, 7, data[7]);
           receivedSettings.wideVane    = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10]);   
           
-          if(settingsChangedCallback && settingsChangedCallbackOptions & SETTINGS_CHANGED_CALLBACK_READ && receivedSettings != currentSettings) {
+          if(settingsChangedCallback && receivedSettings != currentSettings) {
             currentSettings = receivedSettings;
             settingsChangedCallback();
           } else {

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -35,11 +35,11 @@
 #ifdef ESP8266
 #include <functional>
 #define SETTINGS_CHANGED_CALLBACK_SIGNATURE std::function<void()> settingsChangedCallback
-#define PACKET_RECEIVED_CALLBACK_SIGNATURE std::function<void(byte* data, unsigned int length)> packetReceivedCallback
+#define PACKET_CALLBACK_SIGNATURE std::function<void(byte* data, unsigned int length, char* packetDirection)> packetCallback
 #define ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE std::function<void(unsigned int newTemp)> roomTempChangedCallback
 #else
 #define SETTINGS_CHANGED_CALLBACK_SIGNATURE void (*settingsChangedCallback)();
-#define PACKET_RECEIVED_CALLBACK_SIGNATURE void (*packetReceivedCallback)(byte* data, unsigned int length);
+#define PACKET_CALLBACK_SIGNATURE void (*packetCallback)(byte* data, unsigned int length, char* packetDirection);
 #define ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE void (*roomTempChangedCallback)(unsigned int newTemp);
 #endif
 
@@ -89,7 +89,7 @@ class HeatPump
     const byte VANE[7]           = {0x00,  0x01, 0x02, 0x03, 0x04, 0x05, 0x07};
     const String VANE_MAP[7]     = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
     const byte WIDEVANE[7]       = {0x01, 0x02, 0x03, 0x04, 0x05, 0x08, 0x0c};
-    const String WIDEVANE_MAP[7] = {"<<", "<", "|", ">", ">>", "<>", "SWING"};
+    const String WIDEVANE_MAP[7] = {"<<", "<",  "|",  ">",  ">>", "<>", "SWING"};
     const byte ROOM_TEMP[32]     = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
                                     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f};
     const int ROOM_TEMP_MAP[32]  = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
@@ -115,11 +115,11 @@ class HeatPump
     void createPacket(byte *packet, heatpumpSettings settings);
     void createInfoPacket(byte *packet, byte packetType);
     int readPacket();
-    void writePacket(byte *packet);
+    void writePacket(byte *packet, int length);
 
     // callbacks
     SETTINGS_CHANGED_CALLBACK_SIGNATURE;
-    PACKET_RECEIVED_CALLBACK_SIGNATURE;
+    PACKET_CALLBACK_SIGNATURE;
     ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE;
 
   public:
@@ -152,7 +152,7 @@ class HeatPump
     unsigned int CelsiusToFahrenheit(unsigned int tempC);
 
     void setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE);
-    void setPacketReceivedCallback(PACKET_RECEIVED_CALLBACK_SIGNATURE);
+    void setPacketCallback(PACKET_CALLBACK_SIGNATURE);
     void setRoomTempChangedCallback(ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE);
 
     void sendCustomPacket(byte data[], int len); 

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -67,6 +67,7 @@ class HeatPump
 
     const byte INFOHEADER[5]  = {0xfc, 0x42, 0x01, 0x30, 0x10};
     const byte INFOMODE[2]    = {0x02, 0x03};
+    static const int INFOHEADER_LEN  = 5;
 
     const byte POWER[2]          = {0x00, 0x01};
     const String POWER_MAP[2]    = {"OFF", "ON"};
@@ -84,7 +85,9 @@ class HeatPump
                                     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f};
     const int ROOM_TEMP_MAP[32]  = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
                                     26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
-                                              
+
+    int settingsChangedCallbackOptions;
+
     // these settings will be initialised in connect()
     heatpumpSettings currentSettings;
     heatpumpSettings wantedSettings;
@@ -105,7 +108,8 @@ class HeatPump
     byte checkSum(byte bytes[], int len);
     void createPacket(byte *packet, heatpumpSettings settings);
     void createInfoPacket(byte *packet);
-    int getData();
+    int readPacket();
+    void writePacket(byte *packet);
 
     // callbacks
     SETTINGS_CHANGED_CALLBACK_SIGNATURE;
@@ -137,10 +141,14 @@ class HeatPump
     unsigned int FahrenheitToCelsius(unsigned int tempF);
     unsigned int CelsiusToFahrenheit(unsigned int tempC);
 
-    void setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE);
+    void setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE, byte callbackOptions = (SETTINGS_CHANGED_CALLBACK_READ | SETTINGS_CHANGED_CALLBACK_UPDATE));
     void setPacketReceivedCallback(PACKET_RECEIVED_CALLBACK_SIGNATURE);
     void setRoomTempChangedCallback(ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE);
 
     void sendCustomPacket(byte data[], int len); 
+
+    const static byte SETTINGS_CHANGED_CALLBACK_UPDATE  = B00000001;
+    const static byte SETTINGS_CHANGED_CALLBACK_READ    = B00000010;
+
 };
 #endif

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -66,8 +66,21 @@ class HeatPump
     static const int HEADER_LEN  = 8;
 
     const byte INFOHEADER[5]  = {0xfc, 0x42, 0x01, 0x30, 0x10};
-    const byte INFOMODE[2]    = {0x02, 0x03};
     static const int INFOHEADER_LEN  = 5;
+ 
+    // indexes for INFOMODE array below   
+    const int RQST_PKT_SETTINGS  = 0;
+    const int RQST_PKT_ROOM_TEMP = 1;
+
+    const byte INFOMODE[2]    = {
+      0x02, // request a settings packet - RQST_PKT_SETTINGS
+      0x03  // request the current room temp - RQST_PKT_ROOM_TEMP
+    };
+
+    const int RCVD_PKT_FAIL           = 0;
+    const int RCVD_PKT_SETTINGS       = 1;
+    const int RCVD_PKT_ROOM_TEMP      = 2;
+    const int RCVD_PKT_UPDATE_SUCCESS = 3;
 
     const byte POWER[2]          = {0x00, 0x01};
     const String POWER_MAP[2]    = {"OFF", "ON"};
@@ -95,7 +108,6 @@ class HeatPump
     int currentRoomTemp;
              
     HardwareSerial * _HardSerial;
-    static bool lastUpdateSuccessful;
     static unsigned int lastSend;
     static bool info_mode;
 
@@ -107,7 +119,7 @@ class HeatPump
     bool canSend();
     byte checkSum(byte bytes[], int len);
     void createPacket(byte *packet, heatpumpSettings settings);
-    void createInfoPacket(byte *packet);
+    void createInfoPacket(byte *packet, byte packetType);
     int readPacket();
     void writePacket(byte *packet);
 
@@ -120,7 +132,7 @@ class HeatPump
     HeatPump();
     void connect(HardwareSerial *serial);
     bool update();
-    void sync();
+    void sync(byte packetType = NULL);
     heatpumpSettings getSettings();
     void setSettings(heatpumpSettings settings);
     void setPowerSetting(bool setting);

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -68,10 +68,6 @@ class HeatPump
     const byte INFOHEADER[5]  = {0xfc, 0x42, 0x01, 0x30, 0x10};
     static const int INFOHEADER_LEN  = 5;
  
-    // indexes for INFOMODE array below   
-    const int RQST_PKT_SETTINGS  = 0;
-    const int RQST_PKT_ROOM_TEMP = 1;
-
     const byte INFOMODE[2]    = {
       0x02, // request a settings packet - RQST_PKT_SETTINGS
       0x03  // request the current room temp - RQST_PKT_ROOM_TEMP
@@ -98,8 +94,6 @@ class HeatPump
                                     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f};
     const int ROOM_TEMP_MAP[32]  = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
                                     26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
-
-    int settingsChangedCallbackOptions;
 
     // these settings will be initialised in connect()
     heatpumpSettings currentSettings;
@@ -129,6 +123,10 @@ class HeatPump
     ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE;
 
   public:
+    // indexes for INFOMODE array (public so they can be optionally passed to sync())
+    const int RQST_PKT_SETTINGS  = 0;
+    const int RQST_PKT_ROOM_TEMP = 1;
+
     HeatPump();
     void connect(HardwareSerial *serial);
     bool update();
@@ -153,14 +151,11 @@ class HeatPump
     unsigned int FahrenheitToCelsius(unsigned int tempF);
     unsigned int CelsiusToFahrenheit(unsigned int tempC);
 
-    void setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE, byte callbackOptions = (SETTINGS_CHANGED_CALLBACK_READ | SETTINGS_CHANGED_CALLBACK_UPDATE));
+    void setSettingsChangedCallback(SETTINGS_CHANGED_CALLBACK_SIGNATURE);
     void setPacketReceivedCallback(PACKET_RECEIVED_CALLBACK_SIGNATURE);
     void setRoomTempChangedCallback(ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE);
 
     void sendCustomPacket(byte data[], int len); 
-
-    const static byte SETTINGS_CHANGED_CALLBACK_UPDATE  = B00000001;
-    const static byte SETTINGS_CHANGED_CALLBACK_READ    = B00000010;
 
 };
 #endif


### PR DESCRIPTION
This pull request resolves the issues identified in #9 and #10.

Note that public method setPacketReceivedCallback() has changed to setPacketCallback() and has an extra parameter. Function declaration is now:

```
void HeatPump::setPacketCallback(void (*packetCallback)(byte* data, unsigned int length, char* packetDirection));
```

I have tested the code and my heatpump, and @uronito has confirmed the new code works too. See https://github.com/SwiCago/HeatPump/issues/11#issuecomment-280637344 for more info.