### PR TITLE
mqtt example: roomTempChangedCallback and settings header file

### DIFF
--- a/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.h
+++ b/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.h
@@ -1,0 +1,24 @@
+// wifi settings
+const char* ssid     = "<YOUR WIFI SSID GOES HERE>";
+const char* password = "<YOUR WIFI PASSWORD GOES HERE>";
+
+// mqtt server settings
+const char* mqtt_server   = "<YOUR MQTT BROKER IP/HOSTNAME GOES HERE>";
+const int mqtt_port       = 1883;
+const char* mqtt_username = "<YOUR MQTT USERNAME GOES HERE>";
+const char* mqtt_password = "<YOUR MQTT PASSWORD GOES HERE>";
+
+// mqtt client settings
+const char* client_id                   = "heatpump-controller-1"; // Must be unique on the MQTT network
+const char* heatpump_topic              = "heatpump";
+const char* heatpump_set_topic          = "heatpump/set";
+const char* heatpump_temperature_topic  = "heatpump/temperature";
+const char* heatpump_debug_topic        = "heatpump/debug";
+const char* heatpump_debug_set_topic    = "heatpump/debug/set";
+
+// pinouts
+const int redLedPin  = 0; // Onboard LED = digital pin 0 (red LED on adafruit ESP8266 huzzah)
+const int blueLedPin = 2; // Onboard LED = digital pin 0 (blue LED on adafruit ESP8266 huzzah)
+
+// sketch settings
+const unsigned int SEND_ROOM_TEMP_INTERVAL_MS = 60000;


### PR DESCRIPTION
- made use of the roomTempChangedCallback callback to send current room temp as it changes. 60s periodical send is still there too
- also added retain flag to room temperature message
- these changes should close https://github.com/SwiCago/HeatPump/issues/8
- added SEND_ROOM_TEMP_INTERVAL_MS constant (set to 60000ms - 60s) for setting temperature update interval
- added wifi/mqtt/etc settings to a header file, to make maintaining the example easier when pushing to github!
- few other general formatting and removed unused lastSettings variable

Tested on my heatpump, no problems. This will close #8 too.