### PR TITLE
add keywords.txt, connect() uses writePacket(), general code clean

### DIFF
--- a/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
+++ b/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
@@ -13,7 +13,7 @@ HeatPump hp;
 
 // debug mode, when true, will send all packets received from the heatpump to topic heatpump_debug_topic
 // this can also be set by sending "on" to heatpump_debug_set_topic
-bool _debugMode = false;
+bool _debugMode = true;
 
 void setup() {
   pinMode(redLedPin, OUTPUT);
@@ -34,13 +34,13 @@ void setup() {
   // startup mqtt connection
   mqtt_client.setServer(mqtt_server, mqtt_port);
   mqtt_client.setCallback(mqttCallback);
+  mqttConnect();
 
-  // connect to the heatpump
-  hp.connect(&Serial);
-  
+  // connect to the heatpump. Callbacks first so that the hpPacketDebug callback is available for connect()
   hp.setSettingsChangedCallback(hpSettingsChanged);
   hp.setRoomTempChangedCallback(sendCurrentRoomTemperature);
   hp.setPacketCallback(hpPacketDebug);
+  hp.connect(&Serial);
 }
 
 void hpSettingsChanged() {
@@ -172,7 +172,7 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
   }
 }
 
-void reconnect() {
+void mqttConnect() {
   // Loop until we're reconnected
   while (!mqtt_client.connected()) {
     // Attempt to connect
@@ -191,7 +191,7 @@ uint lastTempSend = 0;
 
 void loop() {
   if (!mqtt_client.connected()) {
-    reconnect();
+    mqttConnect();
   }
 
   hp.sync();

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,44 @@
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+HeatPump	KEYWORD1
+heatpumpSettings	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+connect	KEYWORD2
+update	KEYWORD2
+sync	KEYWORD2
+getSettings	KEYWORD2
+setSettings	KEYWORD2
+setPowerSetting	KEYWORD2
+getPowerSettingBool	KEYWORD2
+getPowerSettin	KEYWORD2
+setPowerSetting	KEYWORD2
+getModeSetting	KEYWORD2
+setModeSetting	KEYWORD2
+getTemperature	KEYWORD2
+setTemperature	KEYWORD2
+getFanSpeed	KEYWORD2
+setFanSpeed	KEYWORD2
+getVaneSetting	KEYWORD2
+setVaneSetting	KEYWORD2
+getWideVaneSetting	KEYWORD2
+setWideVaneSetting	KEYWORD2
+getRoomTemperature	KEYWORD2
+FahrenheitToCelsius	KEYWORD2
+CelsiusToFahrenheit	KEYWORD2
+setSettingsChangedCallback	KEYWORD2
+setPacketCallback	KEYWORD2
+setRoomTempChangedCallback	KEYWORD2
+sendCustomPacket	KEYWORD2
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+
+RQST_PKT_SETTINGS	LITERAL1
+RQST_PKT_ROOM_TEMP	LITERAL1

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -35,12 +35,12 @@
 #ifdef ESP8266
 #include <functional>
 #define SETTINGS_CHANGED_CALLBACK_SIGNATURE std::function<void()> settingsChangedCallback
-#define PACKET_CALLBACK_SIGNATURE std::function<void(byte* data, unsigned int length, char* packetDirection)> packetCallback
-#define ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE std::function<void(unsigned int newTemp)> roomTempChangedCallback
+#define PACKET_CALLBACK_SIGNATURE std::function<void(byte* packet, unsigned int length, char* packetDirection)> packetCallback
+#define ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE std::function<void(unsigned int currentRoomTemperature)> roomTempChangedCallback
 #else
 #define SETTINGS_CHANGED_CALLBACK_SIGNATURE void (*settingsChangedCallback)();
-#define PACKET_CALLBACK_SIGNATURE void (*packetCallback)(byte* data, unsigned int length, char* packetDirection);
-#define ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE void (*roomTempChangedCallback)(unsigned int newTemp);
+#define PACKET_CALLBACK_SIGNATURE void (*packetCallback)(byte* packet, unsigned int length, char* packetDirection);
+#define ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE void (*roomTempChangedCallback)(unsigned int currentRoomTemperature);
 #endif
 
 typedef uint8_t byte;
@@ -60,6 +60,9 @@ bool operator!=(const heatpumpSettings& lhs, const heatpumpSettings& rhs);
 class HeatPump
 {
   private:
+    static const int PACKET_LEN = 22;
+    static const int PACKET_SENT_INTERVAL_MS = 1000;
+
     const byte CONNECT[8] = {0xfc, 0x5a, 0x01, 0x30, 0x02, 0xca, 0x01, 0xa8};
     const byte HEADER[8]  = {0xfc, 0x41, 0x01, 0x30, 0x10, 0x01, 0x9f, 0x00};
     static const int CONNECT_LEN = 8;
@@ -102,8 +105,8 @@ class HeatPump
     int currentRoomTemp;
              
     HardwareSerial * _HardSerial;
-    static unsigned int lastSend;
-    static bool info_mode;
+    unsigned int lastSend;
+    bool infoMode;
 
     String lookupByteMapValue(const String valuesMap[], const byte byteMap[], int len, byte byteValue);
     int    lookupByteMapValue(const int valuesMap[], const byte byteMap[], int len, byte byteValue);


### PR DESCRIPTION
**added keywords.txt file**
- because who doesn't like highlighted keywords!

**changed connect() to use writePacket() and general clean up  …**
- connect() uses writePacket() now so that all packet writing is done through this method, meaning that the packetCallback will be fired when connecting to the heatpump (previously it wasn't)
- removed lots of magic numbers
- ensured all variables are in camelCase and not underscore_separated
- general formatting - consistent curly brace position on if() and for()

**reordered code to capture connect() packets for debug  …**
- previously connect was called before the packetCallback was set, and before mqtt connection was established