### PR TITLE
Auto update implementation

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -53,6 +53,7 @@ bool operator!(const heatpumpSettings& settings) {
 HeatPump::HeatPump() {
   lastSend = 0;
   infoMode = false;
+  autoUpdate = false;
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
@@ -95,13 +96,16 @@ bool HeatPump::update() {
 }
 
 void HeatPump::sync(byte packetType) {
-  if(canSend()) {
+  if(autoUpdate && wantedSettings.power != NULL && wantedSettings != currentSettings && packetType == PACKET_TYPE_DEFAULT) {
+    update();
+  }
+  else if(canSend()) {
     byte packet[PACKET_LEN] = {};
     createInfoPacket(packet, packetType);
     writePacket(packet, PACKET_LEN);
   }
 
-  readPacket(); 
+  readPacket();
 }
 
 
@@ -403,8 +407,8 @@ int HeatPump::readPacket() {
             currentSettings = receivedSettings;
           }
 
-          // if wantedSettings is null (indicating that this is the first time we have synced with the heatpump, set it to receivedSettings
-          if(!wantedSettings) {
+          // if wantedSettings.power is null (indicating that this is the first time we have synced with the heatpump, set it to receivedSettings
+          if (autoUpdate || wantedSettings.power == NULL) {
             wantedSettings = receivedSettings;
           }
 

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -104,6 +104,7 @@ class HeatPump
     heatpumpSettings wantedSettings;
   
     int currentRoomTemp;
+    bool autoUpdate;
              
     HardwareSerial * _HardSerial;
     unsigned int lastSend;


### PR DESCRIPTION
So it turns out that the `!wantedSettings` was causing the issues. wantedSettings is always initialised as its a struct. 

I updated wantedSettings when autoUpdate on because if you are using the buttons on the remote then it will never update wantedSettings. Maybe this should always happen .....???