### PR TITLE
wide vane (horizontal vane) is now working!

### DIFF
--- a/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
+++ b/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
@@ -156,14 +156,25 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 
     if (root.containsKey("custom")) {
       String custom = root["custom"];
-      custom.toUpperCase();
-      char chars[20];
-      custom.toCharArray(chars,20);
+      
+      char buf[custom.length()];
+      custom.toCharArray(buf, custom.length());
+
       byte bytes[20];
-      for(int i = 0; i < 20; i++)
+      int i = 0;
+      
+      char * pch;
+      pch = strtok(buf," ");
+      while (pch != NULL)
       {
-        bytes[i] = getVal(chars[i]);
-      }  
+        bytes[i] = strtol(pch, NULL, 16);
+        pch = strtok(NULL, " ");
+        i++;
+      }
+
+      // dump the packet so we can see what it is. handy because you can run the code without connecting the ESP to the heatpump, and test sending custom packets
+      hpPacketDebug(bytes, 20, "customPacket");
+
       hp.sendCustomPacket(bytes,20);
     }   
     else { 

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -223,16 +223,15 @@ void HeatPump::setRoomTempChangedCallback(ROOM_TEMP_CHANGED_CALLBACK_SIGNATURE) 
 //#### WARNING, THE FOLLOWING METHOD CAN F--K YOUR HP UP, USE WISELY ####
 void HeatPump::sendCustomPacket(byte data[], int len) {
   while(!canSend()) { delay(10); }
-  len += 2;                          //+2, for FC and CHKSUM
-  byte packet[len];
+  byte packet[PACKET_LEN];
   packet[0] = 0xfc;
-  for (int i = 0; i < len-1; i++) {
-    packet[i+1] = data[i]; 
+  for (int i = 0; i < len; i++) {
+    packet[(i+1)] = data[i]; 
   }
-  byte chkSum = checkSum(packet, len-1);
-  packet[len] = chkSum;
+  byte chkSum = checkSum(packet, 21);
+  packet[21] = chkSum;
 
-  writePacket(packet, len);
+  writePacket(packet, PACKET_LEN);
   delay(1000);
 }
 
@@ -297,32 +296,32 @@ void HeatPump::createPacket(byte *packet, heatpumpSettings settings) {
   }
   if(settings.power != currentSettings.power) {
     packet[8]  = POWER[lookupByteMapIndex(POWER_MAP, 2, settings.power)];
-    packet[6] += CONTROL_PACKET[0];
+    packet[6] += CONTROL_PACKET_1[0];
   }
   if(settings.mode!= currentSettings.mode) {
     packet[9]  = MODE[lookupByteMapIndex(MODE_MAP, 5, settings.mode)];
-    packet[6] += CONTROL_PACKET[1];
+    packet[6] += CONTROL_PACKET_1[1];
   }
   if(!tempMode && settings.temperature!= currentSettings.temperature) {
     packet[10] = TEMP[lookupByteMapIndex(TEMP_MAP, 16, settings.temperature)];
-    packet[6] += CONTROL_PACKET[2];
+    packet[6] += CONTROL_PACKET_1[2];
   }
   else if(tempMode && settings.temperature!= currentSettings.temperature) {
     float temp = (settings.temperature * 2) + 128;
     packet[19] = (int)temp;
-    packet[6] += CONTROL_PACKET[2];
+    packet[6] += CONTROL_PACKET_1[2];
   }
   if(settings.fan!= currentSettings.fan) {
     packet[11] = FAN[lookupByteMapIndex(FAN_MAP, 6, settings.fan)];
-    packet[6] += CONTROL_PACKET[3];
+    packet[6] += CONTROL_PACKET_1[3];
   }
   if(settings.vane!= currentSettings.vane) {
     packet[12] = VANE[lookupByteMapIndex(VANE_MAP, 7, settings.vane)];
-    packet[6] += CONTROL_PACKET[4];
+    packet[6] += CONTROL_PACKET_1[4];
   }
   if(settings.wideVane!= currentSettings.wideVane) {
-    packet[15] = WIDEVANE[lookupByteMapIndex(WIDEVANE_MAP, 7, settings.wideVane)];
-    packet[6] += CONTROL_PACKET[5];
+    packet[18] = WIDEVANE[lookupByteMapIndex(WIDEVANE_MAP, 7, settings.wideVane)];
+    packet[7] += CONTROL_PACKET_2[0];
   }
   // add the checksum
   byte chkSum = checkSum(packet, 21);

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -82,8 +82,10 @@ class HeatPump
     const int RCVD_PKT_ROOM_TEMP      = 2;
     const int RCVD_PKT_UPDATE_SUCCESS = 3;
 
-    const byte CONTROL_PACKET[6] = {0x01, 0x02, 0x04, 0x08, 0x10, 0x80};
-                                  //"POWER","MODE","TEMP","FAN","WANE","WIDEVANE"};
+    const byte CONTROL_PACKET_1[5] = {0x01, 0x02, 0x04, 0x08, 0x10};
+                                  //{"POWER","MODE","TEMP","FAN","VANE"};
+    const byte CONTROL_PACKET_2[1] = {0x01};
+                                  //{"WIDEVANE"};
     const byte POWER[2]          = {0x00, 0x01};
     const String POWER_MAP[2]    = {"OFF", "ON"};
     const byte MODE[5]           = {0x01,   0x02,  0x03, 0x07, 0x08};


### PR DESCRIPTION
- the wide vane setting is sent on byte 18 (assuming first byte is 0)
- the bitmap control byte value for this packet is set in byte 7 (not 6 as for the other settings) and has a value of 0x01

This resolves #7 and is being discussed in #25 as well.

I also did some work on the custom packet sender to make it work. Currently (for example) I send a payload over mqtt of:

```
{"custom": "41 01 30 10 01 08 01 00 00 07 02 00 00 00 00 00 00 08 00 00 "}
```

note that the space at the end is important, or else the last byte isn't sent