### PR TITLE
swap serial UART to alternate pins

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -82,12 +82,18 @@ HeatPump::HeatPump() {
 
 // Public Methods //////////////////////////////////////////////////////////////
 
-bool HeatPump::connect(HardwareSerial *serial) {
+void HeatPump::serial(HardwareSerial *serial) {
   if(serial != NULL) {
     _HardSerial = serial;
+    _HardSerial->begin(2400, SERIAL_8E1);
   }
   connected = false;
-  _HardSerial->begin(2400, SERIAL_8E1);
+}
+
+bool HeatPump::connect(HardwareSerial *serial) {
+  if(serial != NULL) {
+    this->serial(serial);
+  }
   
   // settle before we start sending packets
   delay(2000);

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -180,6 +180,7 @@ class HeatPump
 
     // general
     HeatPump();
+    void serial(HardwareSerial *serial); 
     bool connect(HardwareSerial *serial);
     bool update();
     void sync(byte packetType = PACKET_TYPE_DEFAULT);


### PR DESCRIPTION
Split `connect()` method into two so the serial port init can be called separately via `serial()`.  This allows a `serial.swap()` to be included in between when using an ESP8266 module.

Existing call syntax preserved, but also allows the following when using an ESP module:
```
heatpump.serial(&Serial);
Serial.swap();
heatpump.connect(NULL);
```

