### PR TITLE
Reduce excessive delay().

### DIFF
--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -164,6 +164,8 @@ class HeatPump
     byte checkSum(byte bytes[], int len);
     void createPacket(byte *packet, heatpumpSettings settings);
     void createInfoPacket(byte *packet, byte packetType);
+    // Spend up to 1 second trying to read a single byte from the serial port.
+    byte readByte();
     int readPacket();
     void writePacket(byte *packet, int length);
 


### PR DESCRIPTION
Instead of relying on fixed delays to get the receive buffer full, query the
hardware to see when more characters have been received. This reduces the time
to execute most calls from around a second to around 250ms.