### PR TITLE
Update Temp State topic

### DIFF
--- a/integrations/home-assistant.io/README.md
+++ b/integrations/home-assistant.io/README.md
@@ -2,15 +2,15 @@
 
 ###Installation:
 
-copy mitsubishi_mqtt.py to <home assistant config directory>/custom_components/climate/
+Copy mitsubishi_mqtt.py to <home assistant config directory>/custom_components/climate/
 
-add the following to your configuration:
+Add the following to your configuration:
 ```c++
 climate:
    - platform: mitsubishi_mqtt
      name: "Mistubishi Heatpump"
      command_topic: "heatpump/set"
-     temperature_state_topic: "heatpump/temperature"
+     temperature_state_topic: "heatpump/status"
      state_topic: "heatpump"
 
 ```


### PR DESCRIPTION
The Temperature topic in the readme was invalidated last year according to the commit history.  The HASSIO Plugin appears to parse the data from the Status JSON now.

Took me a bit to figure out why things were not working...  Figured I would save others the time.