### PR TITLE
Use const char* instead of strings

### DIFF
--- a/examples/HP_cntrl_Fancy_web/HP_cntrl_Fancy_web.ino
+++ b/examples/HP_cntrl_Fancy_web/HP_cntrl_Fancy_web.ino
@@ -54,96 +54,96 @@ void handle_root() {
   String toSend = html;
   toSend.replace("_RATE_", "60");
   toSend.replace("_ROOMTEMP_", String(hp.getRoomTemperature()));
-  toSend.replace("_POWER_",settings.power == "ON" ? "checked" : "");
-  if(settings.mode == "HEAT") {
+  toSend.replace("_POWER_", strcmp(settings.power, "ON") == 0 ? "checked" : "");
+  if(strcmp(settings.mode, "HEAT") == 0) {
     toSend.replace("_MODE_H_","checked");
   }
-  else if(settings.mode == "DRY") {
+  else if(strcmp(settings.mode, "DRY") == 0) {
     toSend.replace("_MODE_D_","checked");
   }
-  else if(settings.mode == "COOL") {
+  else if(strcmp(settings.mode, "COOL") == 0) {
     toSend.replace("_MODE_C_","checked");
   }
-  else if(settings.mode == "FAN") {
+  else if(strcmp(settings.mode, "FAN") == 0) {
     toSend.replace("_MODE_F_","checked");
   }
-  else if(settings.mode == "AUTO") {
+  else if(strcmp(settings.mode, "AUTO") == 0) {
     toSend.replace("_MODE_A_","checked");
   }
-  if(settings.fan == "AUTO") {
+  if(strcmp(settings.fan, "AUTO") == 0) {
     toSend.replace("_FAN_A_","checked");
   }
-  else if(settings.fan == "QUIET") {
+  else if(strcmp(settings.fan, "QUIET") == 0) {
     toSend.replace("_FAN_Q_","checked");
   }
-  else if(settings.fan == "1") {
+  else if(strcmp(settings.fan, "1") == 0) {
     toSend.replace("_FAN_1_","checked");
   }
-  else if(settings.fan == "2") {
+  else if(strcmp(settings.fan, "2") == 0) {
     toSend.replace("_FAN_2_","checked");
   }
-  else if(settings.fan == "3") {
+  else if(strcmp(settings.fan, "3") == 0) {
     toSend.replace("_FAN_3_","checked");
   }
-  else if(settings.fan == "4") {
+  else if(strcmp(settings.fan, "4") == 0) {
     toSend.replace("_FAN_4_","checked");
   }
  
   toSend.replace("_VANE_V_",settings.vane);
-  if(settings.vane == "AUTO") {
+  if(strcmp(settings.vane, "AUTO") == 0) {
     toSend.replace("_VANE_C_","rotate0");
     toSend.replace("_VANE_T_","AUTO");
   }
-  else if(settings.vane == "1") {
+  else if(strcmp(settings.vane, "1") == 0) {
     toSend.replace("_VANE_C_","rotate0");
     toSend.replace("_VANE_T_","&#10143;");
   }
-  else if(settings.vane == "2") {
+  else if(strcmp(settings.vane, "2") == 0) {
     toSend.replace("_VANE_C_","rotate22");
     toSend.replace("_VANE_T_","&#10143;");
   }
-  else if(settings.vane == "3") {
+  else if(strcmp(settings.vane, "3") == 0) {
     toSend.replace("_VANE_C_","rotate45");
     toSend.replace("_VANE_T_","&#10143;");
   }
-  else if(settings.vane == "4") {
+  else if(strcmp(settings.vane, "4") == 0) {
     toSend.replace("_VANE_C_","rotate67");
     toSend.replace("_VANE_T_","&#10143;");
   }
-  else if(settings.vane == "5") {
+  else if(strcmp(settings.vane, "5") == 0) {
     toSend.replace("_VANE_C_","rotate90");
     toSend.replace("_VANE_T_","&#10143;");
   }
-  else if(settings.vane == "SWING") {
+  else if(strcmp(settings.vane, "SWING") == 0) {
     toSend.replace("_VANE_C_","rotateV");
     toSend.replace("_VANE_T_","&#10143;");
   }
   toSend.replace("_WIDEVANE_V_",settings.wideVane);
-  if(settings.wideVane == "<<") {
+  if(strcmp(settings.wideVane, "<<") == 0) {
     toSend.replace("_WIDEVANE_C_","rotate157");
     toSend.replace("_WIDEVANE_T_","&#10143;");
   }
-  else if(settings.wideVane == "<") {
+  else if(strcmp(settings.wideVane, "<") == 0) {
     toSend.replace("_WIDEVANE_C_","rotate124");
     toSend.replace("_WIDEVANE_T_","&#10143;");
   }
-  else if(settings.wideVane == "|") {
+  else if(strcmp(settings.wideVane, "|") == 0) {
     toSend.replace("_WIDEVANE_C_","rotate90");
     toSend.replace("_WIDEVANE_T_","&#10143;");
   }
-  else if(settings.wideVane == ">") {
+  else if(strcmp(settings.wideVane, ">") == 0) {
     toSend.replace("_WIDEVANE_C_","rotate57");
     toSend.replace("_WIDEVANE_T_","&#10143;");
   }
-  else if(settings.wideVane == ">>") {
+  else if(strcmp(settings.wideVane, ">>") == 0) {
     toSend.replace("_WIDEVANE_C_","rotate22");
     toSend.replace("_WIDEVANE_T_","&#10143;");
   }
-  else if(settings.wideVane == "<>") {
+  else if(strcmp(settings.wideVane, "<>") == 0) {
     toSend.replace("_WIDEVANE_C_","");
     toSend.replace("_WIDEVANE_T_","<div class='rotate124'>&#10143;</div>&nbsp;<div class='rotate57'>&#10143;</div>");
   }
-  else if(settings.wideVane == "SWING") {
+  else if(strcmp(settings.wideVane, "SWING") == 0) {
     toSend.replace("_WIDEVANE_C_","rotateH");
     toSend.replace("_WIDEVANE_T_","&#10143;");
   }
@@ -163,7 +163,7 @@ heatpumpSettings change_states(heatpumpSettings settings) {
       update = true;
     }
     if (server.hasArg("MODE")) {
-      settings.mode=server.arg("MODE");
+      settings.mode=server.arg("MODE").c_str();
       update = true;
     }
     if (server.hasArg("TEMP")) {
@@ -171,15 +171,15 @@ heatpumpSettings change_states(heatpumpSettings settings) {
       update = true;
     }
     if (server.hasArg("FAN")) {
-      settings.fan=server.arg("FAN");
+      settings.fan=server.arg("FAN").c_str();
       update = true;
     }
     if (server.hasArg("VANE")) {
-      settings.vane=server.arg("VANE");
+      settings.vane=server.arg("VANE").c_str();
       update = true;
     }
     if (server.hasArg("WIDEVANE")) {
-      settings.wideVane=server.arg("WIDEVANE");
+      settings.wideVane=server.arg("WIDEVANE").c_str();
       update = true;
     }
     if(update) {

--- a/examples/HP_cntrl_esp8266/HP_cntrl_esp8266.ino
+++ b/examples/HP_cntrl_esp8266/HP_cntrl_esp8266.ino
@@ -110,11 +110,11 @@ bool change_states() {
   }
   else {
     if (server.hasArg("POWER")) {
-      hp.setPowerSetting(server.arg("POWER"));
+      hp.setPowerSetting(server.arg("POWER").c_str());
       updated = true;
     }
     if (server.hasArg("MODE")) {
-      hp.setModeSetting(server.arg("MODE"));
+      hp.setModeSetting(server.arg("MODE").c_str());
       updated = true;
     }
     if (server.hasArg("TEMP")) {
@@ -122,15 +122,15 @@ bool change_states() {
       updated = true;
     }
     if (server.hasArg("FAN")) {
-      hp.setFanSpeed(server.arg("FAN"));
+      hp.setFanSpeed(server.arg("FAN").c_str());
       updated = true;
     }
     if (server.hasArg("VANE")) {
-      hp.setVaneSetting(server.arg("VANE"));
+      hp.setVaneSetting(server.arg("VANE").c_str());
       updated = true;
     }
     if (server.hasArg("DIR")) {
-      hp.setWideVaneSetting(server.arg("WIDEVANE"));
+      hp.setWideVaneSetting(server.arg("WIDEVANE").c_str());
       updated = true;
     }
     hp.update(); 

--- a/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
+++ b/examples/mitsubishi_heatpump_mqtt_esp8266/mitsubishi_heatpump_mqtt_esp8266.ino
@@ -164,12 +164,12 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 
     // Step 3: Retrieve the values
     if (root.containsKey("power")) {
-      String power = root["power"];
+      const char* power = root["power"];
       hp.setPowerSetting(power);
     }
 
     if (root.containsKey("mode")) {
-      String mode = root["mode"];
+      const char* mode = root["mode"];
       hp.setModeSetting(mode);
     }
 
@@ -179,17 +179,17 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
     }
 
     if (root.containsKey("fan")) {
-      String fan = root["fan"];
+      const char* fan = root["fan"];
       hp.setFanSpeed(fan);
     }
 
     if (root.containsKey("vane")) {
-      String vane = root["vane"];
+      const char* vane = root["vane"];
       hp.setVaneSetting(vane);
     }
 
     if (root.containsKey("wideVane")) {
-      String wideVane = root["wideVane"];
+      const char* wideVane = root["wideVane"];
       hp.setWideVaneSetting(wideVane);
     }
 

--- a/integrations/OpenHAB/mitsubishi_heatpump_mqtt_esp8266_template/mitsubishi_heatpump_mqtt_esp8266_template.ino
+++ b/integrations/OpenHAB/mitsubishi_heatpump_mqtt_esp8266_template/mitsubishi_heatpump_mqtt_esp8266_template.ino
@@ -161,12 +161,12 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
     // Step 3: Retrieve the values
     if (root.containsKey("power")) {
       String power = root["power"];
-      hp.setPowerSetting(power);
+      hp.setPowerSetting(power.c_str());
     }
 
     if (root.containsKey("mode")) {
       String mode = root["mode"];
-      hp.setModeSetting(mode);
+      hp.setModeSetting(mode.c_str());
     }
 
     if (root.containsKey("temperature")) {
@@ -176,17 +176,17 @@ void mqttCallback(char* topic, byte* payload, unsigned int length) {
 
     if (root.containsKey("fan")) {
       String fan = root["fan"];
-      hp.setFanSpeed(fan);
+      hp.setFanSpeed(fan.c_str());
     }
 
     if (root.containsKey("vane")) {
       String vane = root["vane"];
-      hp.setVaneSetting(vane);
+      hp.setVaneSetting(vane.c_str());
     }
 
     if (root.containsKey("wideVane")) {
       String wideVane = root["wideVane"];
-      hp.setWideVaneSetting(wideVane);
+      hp.setWideVaneSetting(wideVane.c_str());
     }
 
     if(root.containsKey("remoteTemp")) {

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -173,20 +173,30 @@ void HeatPump::setPowerSetting(bool setting) {
   wantedSettings.power = lookupByteMapIndex(POWER_MAP, 2, POWER_MAP[setting ? 1 : 0]) > -1 ? POWER_MAP[setting ? 1 : 0] : POWER_MAP[0];
 }
 
-String HeatPump::getPowerSetting() {
+const char* HeatPump::getPowerSetting() {
   return currentSettings.power;
 }
 
-void HeatPump::setPowerSetting(String setting) {
-  wantedSettings.power = lookupByteMapIndex(POWER_MAP, 2, setting) > -1 ? setting : POWER_MAP[0];
+void HeatPump::setPowerSetting(const char* setting) {
+  int index = lookupByteMapIndex(POWER_MAP, 2, setting);
+  if (index > -1) {
+    wantedSettings.power = POWER_MAP[index];
+  } else {
+    wantedSettings.power = POWER_MAP[0];
+  }
 }
 
-String HeatPump::getModeSetting() {
+const char* HeatPump::getModeSetting() {
   return currentSettings.mode;
 }
 
-void HeatPump::setModeSetting(String setting) {
-  wantedSettings.mode = lookupByteMapIndex(MODE_MAP, 5, setting) > -1 ? setting : MODE_MAP[0];
+void HeatPump::setModeSetting(const char* setting) {
+  int index = lookupByteMapIndex(MODE_MAP, 5, setting);
+  if (index > -1) {
+    wantedSettings.mode = MODE_MAP[index];
+  } else {
+    wantedSettings.mode = MODE_MAP[0];
+  }
 }
 
 float HeatPump::getTemperature() {
@@ -233,28 +243,45 @@ void HeatPump::setRemoteTemperature(float setting) {
   writePacket(packet, PACKET_LEN);
 }
 
-String HeatPump::getFanSpeed() {
+const char* HeatPump::getFanSpeed() {
   return currentSettings.fan;
 }
 
-void HeatPump::setFanSpeed(String setting) {
-  wantedSettings.fan = lookupByteMapIndex(FAN_MAP, 6, setting) > -1 ? setting : FAN_MAP[0];
+
+void HeatPump::setFanSpeed(const char* setting) {
+  int index = lookupByteMapIndex(FAN_MAP, 6, setting);
+  if (index > -1) {
+    wantedSettings.fan = FAN_MAP[index];
+  } else {
+    wantedSettings.fan = FAN_MAP[0];
+  }
 }
 
-String HeatPump::getVaneSetting() {
+const char* HeatPump::getVaneSetting() {
   return currentSettings.vane;
 }
 
-void HeatPump::setVaneSetting(String setting) {
-  wantedSettings.vane = lookupByteMapIndex(VANE_MAP, 7, setting) > -1 ? setting : VANE_MAP[0];
+void HeatPump::setVaneSetting(const char* setting) {
+  int index = lookupByteMapIndex(VANE_MAP, 7, setting);
+  if (index > -1) {
+    wantedSettings.vane = VANE_MAP[index];
+  } else {
+    wantedSettings.vane = VANE_MAP[0];
+  }
 }
 
-String HeatPump::getWideVaneSetting() {
+const char* HeatPump::getWideVaneSetting() {
   return currentSettings.wideVane;
 }
 
-void HeatPump::setWideVaneSetting(String setting) {
+void HeatPump::setWideVaneSetting(const char* setting) {
   wantedSettings.wideVane = lookupByteMapIndex(WIDEVANE_MAP, 7, setting) > -1 ? setting : WIDEVANE_MAP[0];
+  int index = lookupByteMapIndex(WIDEVANE_MAP, 7, setting);
+  if (index > -1) {
+    wantedSettings.wideVane = VANE_MAP[index];
+  } else {
+    wantedSettings.wideVane = VANE_MAP[0];
+  }
 }
 
 bool HeatPump::getIseeBool() { //no setter yet
@@ -335,9 +362,9 @@ int HeatPump::lookupByteMapIndex(const int valuesMap[], int len, int lookupValue
   return -1;
 }
 
-int HeatPump::lookupByteMapIndex(const String valuesMap[], int len, String lookupValue) {
+int HeatPump::lookupByteMapIndex(const char* valuesMap[], int len, const char* lookupValue) {
   for (int i = 0; i < len; i++) {
-    if (valuesMap[i] == lookupValue) {
+    if (strcmp(valuesMap[i], lookupValue) == 0) {
       return i;
     }
   }
@@ -345,7 +372,7 @@ int HeatPump::lookupByteMapIndex(const String valuesMap[], int len, String looku
 }
 
 
-String HeatPump::lookupByteMapValue(const String valuesMap[], const byte byteMap[], int len, byte byteValue) {
+const char* HeatPump::lookupByteMapValue(const char* valuesMap[], const byte byteMap[], int len, byte byteValue) {
   for (int i = 0; i < len; i++) {
     if (byteMap[i] == byteValue) {
       return valuesMap[i];

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -275,7 +275,6 @@ const char* HeatPump::getWideVaneSetting() {
 }
 
 void HeatPump::setWideVaneSetting(const char* setting) {
-  wantedSettings.wideVane = lookupByteMapIndex(WIDEVANE_MAP, 7, setting) > -1 ? setting : WIDEVANE_MAP[0];
   int index = lookupByteMapIndex(WIDEVANE_MAP, 7, setting);
   if (index > -1) {
     wantedSettings.wideVane = VANE_MAP[index];

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -19,7 +19,6 @@
 #ifndef __HeatPump_H__
 #define __HeatPump_H__
 #include <stdint.h>
-#include <WString.h>
 #include <math.h>
 #include <HardwareSerial.h>
 #if defined(ARDUINO) && ARDUINO >= 100
@@ -50,12 +49,12 @@
 typedef uint8_t byte;
 
 struct heatpumpSettings {
-  String power;
-  String mode;
+  const char* power;
+  const char* mode;
   float temperature;
-  String fan;
-  String vane; //vertical vane, up/down
-  String wideVane; //horizontal vane, left/right
+  const char* fan;
+  const char* vane; //vertical vane, up/down
+  const char* wideVane; //horizontal vane, left/right
   bool iSee;   //iSee sensor, at the moment can only detect it, not set it
   bool connected;
 };
@@ -64,7 +63,7 @@ bool operator==(const heatpumpSettings& lhs, const heatpumpSettings& rhs);
 bool operator!=(const heatpumpSettings& lhs, const heatpumpSettings& rhs);
 
 struct heatpumpTimers {
-  String mode;
+  const char* mode;
   int onMinutesSet;
   int onMinutesRemaining;
   int offMinutesSet;
@@ -121,23 +120,23 @@ class HeatPump
     const byte CONTROL_PACKET_2[1] = {0x01};
                                    //{"WIDEVANE"};
     const byte POWER[2]            = {0x00, 0x01};
-    const String POWER_MAP[2]      = {"OFF", "ON"};
+    const char* POWER_MAP[2]       = {"OFF", "ON"};
     const byte MODE[5]             = {0x01,   0x02,  0x03, 0x07, 0x08};
-    const String MODE_MAP[5]       = {"HEAT", "DRY", "COOL", "FAN", "AUTO"};
+    const char* MODE_MAP[5]        = {"HEAT", "DRY", "COOL", "FAN", "AUTO"};
     const byte TEMP[16]            = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f};
     const int TEMP_MAP[16]         = {31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16};
     const byte FAN[6]              = {0x00,  0x01,   0x02, 0x03, 0x05, 0x06};
-    const String FAN_MAP[6]        = {"AUTO", "QUIET", "1", "2", "3", "4"};
+    const char* FAN_MAP[6]         = {"AUTO", "QUIET", "1", "2", "3", "4"};
     const byte VANE[7]             = {0x00,  0x01, 0x02, 0x03, 0x04, 0x05, 0x07};
-    const String VANE_MAP[7]       = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
+    const char* VANE_MAP[7]        = {"AUTO", "1", "2", "3", "4", "5", "SWING"};
     const byte WIDEVANE[7]         = {0x01, 0x02, 0x03, 0x04, 0x05, 0x08, 0x0c};
-    const String WIDEVANE_MAP[7]   = {"<<", "<",  "|",  ">",  ">>", "<>", "SWING"};
+    const char* WIDEVANE_MAP[7]    = {"<<", "<",  "|",  ">",  ">>", "<>", "SWING"};
     const byte ROOM_TEMP[32]       = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
                                       0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f};
     const int ROOM_TEMP_MAP[32]    = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
                                       26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
     const byte TIMER_MODE[4]       = {0x00,  0x01,  0x02, 0x03};
-    const String TIMER_MODE_MAP[4] = {"NONE", "OFF", "ON", "BOTH"};
+    const char* TIMER_MODE_MAP[4]  = {"NONE", "OFF", "ON", "BOTH"};
 
     static const int TIMER_INCREMENT_MINUTES = 10;
 
@@ -157,9 +156,9 @@ class HeatPump
     bool tempMode;
     bool externalUpdate;
 
-    String lookupByteMapValue(const String valuesMap[], const byte byteMap[], int len, byte byteValue);
+    const char* lookupByteMapValue(const char* valuesMap[], const byte byteMap[], int len, byte byteValue);
     int    lookupByteMapValue(const int valuesMap[], const byte byteMap[], int len, byte byteValue);
-    int    lookupByteMapIndex(const String valuesMap[], int len, String lookupValue);
+    int    lookupByteMapIndex(const char* valuesMap[], int len, const char* lookupValue);
     int    lookupByteMapIndex(const int valuesMap[], int len, int lookupValue);
 
     bool canSend(bool isInfo);
@@ -198,19 +197,19 @@ class HeatPump
     void setSettings(heatpumpSettings settings);
     void setPowerSetting(bool setting);
     bool getPowerSettingBool(); 
-    String getPowerSetting();
-    void setPowerSetting(String setting);
-    String getModeSetting();
-    void setModeSetting(String setting);
+    const char* getPowerSetting();
+    void setPowerSetting(const char* setting);
+    const char* getModeSetting();
+    void setModeSetting(const char* setting);
     float getTemperature();
     void setTemperature(float setting);
     void setRemoteTemperature(float setting);
-    String getFanSpeed();
-    void setFanSpeed(String setting);
-    String getVaneSetting();
-    void setVaneSetting(String setting);
-    String getWideVaneSetting();
-    void setWideVaneSetting(String setting);
+    const char* getFanSpeed();
+    void setFanSpeed(const char* setting);
+    const char* getVaneSetting();
+    void setVaneSetting(const char* setting);
+    const char* getWideVaneSetting();
+    void setWideVaneSetting(const char* setting);
     bool getIseeBool();
 
     // status


### PR DESCRIPTION
As discussed in #96 and previously attempted in #60, I've converted all the use of `String` to store the various settings values to `const char*`. This should reduce memory usage at little cost to library users, who can continue to wrap the `char*` with `String` instances if they like.

I've also updated - but *not tested on hardware* - the examples.