### PR TITLE
Add `self.hass` attribute to please parent-class accessor

### DIFF
--- a/integrations/home-assistant.io/mitsubishi_mqtt.py
+++ b/integrations/home-assistant.io/mitsubishi_mqtt.py
@@ -72,6 +72,7 @@ class MqttClimate(ClimateDevice):
         """Initialize the MQTT Heatpump."""
         self._state = False
         self._hass = hass
+        self.hass = hass
         self._name = name
         self._state_topic = state_topic
         self._temperature_state_topic = temperature_state_topic


### PR DESCRIPTION
While the integration stores/accesses the hass instance at `_hass`, its
parent expects `hass`.