### PR TITLE
fix compiler warnings

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -83,7 +83,7 @@ HeatPump::HeatPump() {
 // Public Methods //////////////////////////////////////////////////////////////
 
 bool HeatPump::connect(HardwareSerial *serial) {
-	connect(serial,true);
+	return connect(serial,true);
 }
 
 bool HeatPump::connect(HardwareSerial *serial, bool retry) {
@@ -462,8 +462,12 @@ void HeatPump::createInfoPacket(byte *packet, byte packetType) {
     packet[5] = INFOMODE[packetType];
   } else {
     // request current infoMode, and increment for the next request
-    packet[5] = INFOMODE[infoMode]; 
-    infoMode = (infoMode == (INFOMODE_LEN - 1)) ? 0 : infoMode += 1;
+    packet[5] = INFOMODE[infoMode];
+    if(infoMode == (INFOMODE_LEN - 1)) {
+      infoMode = 0;
+    } else {
+      infoMode++;
+    }
   }
 
   // pad the packet out
@@ -592,7 +596,6 @@ int HeatPump::readPacket() {
             case 0x03: { //Room temperature reading
               heatpumpStatus receivedStatus;
 
-              float receivedRoomTemp;
               if(data[6] != 0x00) {
                 int temp = data[6];
                 temp -= 128;


### PR DESCRIPTION
fix these 3 compiler warnings:

HeatPump.cpp: In member function 'bool HeatPump::connect(HardwareSerial*)':
HeatPump.cpp:87:1: warning: no return statement in function returning non-void [-Wreturn-type]
}
^
HeatPump.cpp: In member function 'void HeatPump::createInfoPacket(byte*, byte)':
HeatPump.cpp:466:68: warning: operation on '((HeatPump*)this)->HeatPump::infoMode' may be undefined [-Wsequence-point]
infoMode = (infoMode == (INFOMODE_LEN - 1)) ? 0 : infoMode += 1;
^
HeatPump.cpp: In member function 'int HeatPump::readPacket()':
HeatPump.cpp:595:21: warning: unused variable 'receivedRoomTemp' [-Wunused-variable]
float receivedRoomTemp;