### PR TITLE
This is needed cause of new home assistant rules

### DIFF
--- a/integrations/home-assistant.io/custom_components/mitsubishi_mqtt/manifest.json
+++ b/integrations/home-assistant.io/custom_components/mitsubishi_mqtt/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "mitsubishi_mqtt",
+    "name": "mitsubishi_mqtt",
+    "documentation": "https://github.com/SwiCago/HeatPump/tree/master/integrations/home-assistant.io",
+    "dependencies": ["mqtt"],
+    "codeowners": [],
+    "requirements": []
+}


### PR DESCRIPTION
HA need a manifest file or it will not load the component properly