### PR TITLE
Make setRemoteTemperature work with the European MSZ-FH series.

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -242,8 +242,10 @@ void HeatPump::setRemoteTemperature(float setting) {
     setting = setting * 2;
     setting = round(setting);
     setting = setting / 2;
-    float temp = (setting * 2) + 128;
-    packet[8] = (int)temp;
+    float temp1 = 3 + ((setting - 10) * 2);
+    packet[7] = (int)temp1;
+    float temp2 = (setting * 2) + 128;
+    packet[8] = (int)temp2;
   }
   else {
     packet[6] = 0x00;


### PR DESCRIPTION
I had the issue described in #69 where setting remote temperature made the heat pump report 10 degrees with an older MSZ-FH35 from 2009. After poking around with custom packets I found that byte 7 affects the temperature with this model. Given the reaction to different values I found the formula used in this patch to work. I've no idea whether this is in fact correct, but at least the reported room temperature follows the set ones. It seems to support 0.5 degree resolution even though the requested temperature can only be set in 1 degree increments.

This patch assumes the devices that use byte 8 don't mind byte 7 being set. If that's not the case, this obviously won't work for everyone.