### PR TITLE
Make applications more responsive by removing the delay in sync()

### DIFF
--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -148,6 +148,7 @@ class HeatPump
   
     HardwareSerial * _HardSerial;
     unsigned long lastSend;
+    bool waitForRead;
     int infoMode;
     unsigned long lastRecv;
     bool connected = false;
@@ -163,6 +164,7 @@ class HeatPump
     int    lookupByteMapIndex(const int valuesMap[], int len, int lookupValue);
 
     bool canSend(bool isInfo);
+    bool canRead();
     byte checkSum(byte bytes[], int len);
     void createPacket(byte *packet, heatpumpSettings settings);
     void createInfoPacket(byte *packet, byte packetType);
@@ -218,6 +220,7 @@ class HeatPump
     heatpumpStatus getStatus();
     float getRoomTemperature();
     bool getOperating();
+    bool isConnected();
 
     // helpers
     float FahrenheitToCelsius(int tempF);


### PR DESCRIPTION
sync() will now return immediately after sending instead of waiting a full second before reading. 

This speeds up the loop() and allows me to respond to http requests much quicker.

A flag is set to schedule the reading after the chosen delay time has passed. The new canRead() function controls the reading like canSend() does control the sending.

Additionally (and not related to the timing issue) I have added a isConnected() method to expose the connected attribute to library users.
