### PR TITLE
Allow explicitly setting baud rate

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -84,12 +84,17 @@ HeatPump::HeatPump() {
 // Public Methods //////////////////////////////////////////////////////////////
 
 bool HeatPump::connect(HardwareSerial *serial) {
-	return connect(serial,true);
+	return connect(serial, 0);
 }
 
-bool HeatPump::connect(HardwareSerial *serial, bool retry) {
+bool HeatPump::connect(HardwareSerial *serial, int bitrate) {
   if(serial != NULL) {
     _HardSerial = serial;
+  }
+  bool retry = false;
+  if(bitrate == 0) {
+    bitrate = 2400;
+    retry = true;
   }
   connected = false;
   _HardSerial->begin(bitrate, SERIAL_8E1);
@@ -108,8 +113,7 @@ bool HeatPump::connect(HardwareSerial *serial, bool retry) {
   while(!canRead()) { delay(10); }
   int packetType = readPacket();
   if(packetType != RCVD_PKT_CONNECT_SUCCESS && retry){
-	  bitrate = (bitrate == 2400 ? 9600 : 2400);
-	  return connect(serial, false);
+	  return connect(serial, 9600);
   }
   return packetType == RCVD_PKT_CONNECT_SUCCESS;
   //}

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -31,7 +31,7 @@
  * Callback function definitions. Code differs for the ESP8266 platform, which requires the functional library.
  * Based on callback implementation in the Arduino Client for MQTT library (https://github.com/knolleary/pubsubclient)
  */
-#ifdef ESP8266
+#if defined(ESP8266) || defined(ESP32)
 #include <functional>
 #define ON_CONNECT_CALLBACK_SIGNATURE std::function<void()> onConnectCallback
 #define SETTINGS_CHANGED_CALLBACK_SIGNATURE std::function<void()> settingsChangedCallback

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -157,7 +157,6 @@ class HeatPump
     bool tempMode;
     bool externalUpdate;
     bool wideVaneAdj;
-    int bitrate = 2400;
 
     const char* lookupByteMapValue(const char* valuesMap[], const byte byteMap[], int len, byte byteValue);
     int    lookupByteMapValue(const int valuesMap[], const byte byteMap[], int len, byte byteValue);
@@ -190,7 +189,7 @@ class HeatPump
     // general
     HeatPump();
     bool connect(HardwareSerial *serial);
-    bool connect(HardwareSerial *serial, bool retry);
+    bool connect(HardwareSerial *serial, int bitrate);
     bool update();
     void sync(byte packetType = PACKET_TYPE_DEFAULT);
     void enableExternalUpdate();


### PR DESCRIPTION
I found that this was required to get the MSZ-GB50VA working, as described in the commit message. 

I also fixed the callback signature definitions for ESP32.