### PR TITLE
Updated readme to explain auto update and external update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,31 @@ By default the library ignores changes made from other sources (usually, the IR 
 
 If you want to also allow manual control and allow the library to update its settings from the current state of the heat pump you need to call `enableExternalUpdate()`. This will also enable automatic updates.
 
+### Callbacks
+
+Instead of manually checking settings changes on each loop, you can set callback functions to be called when the current heat pump status or settings change:
+
+```
+void hpSettingsChanged() {
+  // ...
+}
+
+void hpStatusChanged(heatpumpStatus currentStatus) {
+  // ...
+}
+
+void setup() {
+  hp.setSettingsChangedCallback(hpSettingsChanged);
+  hp.setStatusChangedCallback(hpStatusChanged);
+
+  hp.connect(&Serial);
+}
+```
+
+The callbacks will be called as necessary by the `sync()` method.
+
+You can see this in use in the [MQTT example](examples/mitsubishi_heatpump_mqtt_esp8266_esp32/mitsubishi_heatpump_mqtt_esp8266_esp32.ino).
+
 ## Contents
 
 - sources

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ hp.update();
 
 [See heatPump_test.ino](examples/heatPump_test/heatPump_test.ino)
 
+You can make the library automatically send new settings to the heat pump by calling `enableAutoUpdate()`. When auto update is enabled the call to `update()` in the above example is not necessary, the new settings will be sent to the heat pump on the next call to `sync()` in `loop()`.
+
 ### Getting updates from the heat pump
 
 ```c++
@@ -46,6 +48,10 @@ void loop() {
 }
 
 ```
+
+By default the library ignores changes made from other sources (usually, the IR remote) and reverts them the next time `sync()` is called. This is the intendend behavior when the heat pump is fully controlled by automation.
+
+If you want to also allow manual control and allow the library to update its settings from the current state of the heat pump you need to call `enableExternalUpdate()`. This will also enable automatic updates.
 
 ## Contents
 

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -166,6 +166,10 @@ void HeatPump::enableExternalUpdate() {
   externalUpdate = true;
 }
 
+void HeatPump::disableExternalUpdate() {
+  externalUpdate = false;
+}
+
 void HeatPump::enableAutoUpdate() {
   autoUpdate = true;
 }

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -162,6 +162,7 @@ void HeatPump::sync(byte packetType) {
 }
 
 void HeatPump::enableExternalUpdate() {
+  autoUpdate = true;
   externalUpdate = true;
 }
 

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -193,6 +193,7 @@ class HeatPump
     bool update();
     void sync(byte packetType = PACKET_TYPE_DEFAULT);
     void enableExternalUpdate();
+    void disableExternalUpdate();
     void enableAutoUpdate();
     void disableAutoUpdate();
 


### PR DESCRIPTION
I added some information on how auto update and external update work and their intended use cases.

I also changed `enableExternalUpdate()` to also enable auto update because it had no effect by itself and it’s confusing people.

I believe a better fix would be to make external update work by itself by changing `(autoUpdate && externalUpdate)` to `(autoUpdate || externalUpdate)` but I’m not sure if it’s an acceptable change.