### PR TITLE
Perform case-insensitive lookups

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -395,7 +395,7 @@ int HeatPump::lookupByteMapIndex(const int valuesMap[], int len, int lookupValue
 
 int HeatPump::lookupByteMapIndex(const char* valuesMap[], int len, const char* lookupValue) {
   for (int i = 0; i < len; i++) {
-    if (strcmp(valuesMap[i], lookupValue) == 0) {
+    if (strcasecmp(valuesMap[i], lookupValue) == 0) {
       return i;
     }
   }


### PR DESCRIPTION
**Background:** All `HeatPump::setXXXXXX` functions utilize `HeatPump::lookupByteMapIndex` to look up the index of the provided setting, and ultimately use this index to update `wantedSettings`, which is used to construct packets to send to the Mitsubishi unit. User-provided values are compared with `strcmp` to a list of predefined values in `src/HeatPump.h` to find the index, and ultimately the exact value, of the setting that should be sent to the Mitsubishi unit.
&nbsp;

**Issue:** Users using [mitsubishi2MQTT](https://github.com/gysmo38/mitsubishi2MQTT) to communicate with [Home Assistant](https://www.home-assistant.io/)'s [climate.mqtt](https://www.home-assistant.io/integrations/climate.mqtt) integration are currently unable to control their Mitsubishi units as only lowercase values are allowed in the `modes` and `fan_modes` configuration of this integration.

Taken from https://www.home-assistant.io/integrations/climate.mqtt :
[`modes`](https://www.home-assistant.io/integrations/climate.mqtt#modes)`: ["auto", "off", "cool", "heat", "dry", "fan_only"]`
[`fan_modes`](https://www.home-assistant.io/integrations/climate.mqtt#fan_modes)`: ["auto", "low", "medium", "high"]`

Utilizing any means (the Lovelace UI, automations, Node Red, etc) to control climate.mqtt entities in Home Assistant results in the user-defined setting being sent over MQTT to mitsubishi2MQTT, which leverages HeatPump, resulting in the inability to control the Mitsubishi unit.
&nbsp;

**Example:** A user changes their Mitsubishi unit to "cool" mode, causing a message to be sent over MQTT to mitsubishi2MQTT, which calls `HeatPump::setModeSetting`. As "cool" (case sensitive) is not a valid mode defined in `src/HeatPump.h` (see `MODE_MAP`), `HeatPump::lookupByteMapIndex` fails to find the state that should be used and ultimately returns `(int) 0`. This results in the Mitsubishi unit being set to "HEAT" mode. In the end, the user cannot change the mode from "HEAT" as all of the values they are allowed to provide from Home Assistant are considered invalid by `HeatPump::lookupByteMapIndex`. This behavior affects all `HeatPump::setXXXXXX` functions that use strings for their settings.
&nbsp;

**Resolution:** Currently `HeatPump::lookupByteMapIndex` utilizes `strcmp` to compare the user-provided setting with a list of valid settings defined in `src/HeatPump.h`. As `HeatPump::lookupByteMapIndex` performs a `for..in` loop, comparing the user's input to predefined values defined in `src/HeatPump.h`, we could simply change the comparison to a case-insensitive comparison, `strcasecmp`. The end result is the user's input is checked against all valid settings in a case-insensitive way and a match returns the index of this value, or 0 if there are no matches. In that regard, the behavior is the same. However the user may now additionally specify a lowercase value, meaning the library is a little bit more compatible with Home Assistant. For example, the user will be able to pass "cool" in addition to "COOL" to `HeatPump::setModeSetting`, `HeatPump::lookupByteMapIndex` will return `(int) 2` in both cases, and ultimately `HeatPump::setModeSetting` will update `wantedSettings.mode` to `(byte) 0x03`. This is the desired behavior.
&nbsp;

**Note:** This doesn't resolve issues translating modes that are invalid to Home Assistant (e.g. the Mitsubishi units accept "QUIET" for a fan mode, but - at time of writing - Home Assistant doesn't have a convention for that), however it does allow the user to pass lowercase values to `setPowerSetting`, `setModeSetting`, `setFanSpeed`, `setVaneSetting`, and `setWideVaneSetting`, ultimately resulting in the climate integration working to control the Mitsubishi unit. 