### PR TITLE
Added support for getting and setting generic function codes

### DIFF
--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -113,7 +113,6 @@ class heatpumpFunctions  {
 
     bool operator==(const heatpumpFunctions& rhs);
     bool operator!=(const heatpumpFunctions& rhs);
-
 };
 
 class HeatPump
@@ -177,6 +176,11 @@ class HeatPump
 
     static const int TIMER_INCREMENT_MINUTES = 10;
 
+    const byte FUNCTIONS_SET_PART1 = 0x1F;
+    const byte FUNCTIONS_GET_PART1 = 0x20;
+    const byte FUNCTIONS_SET_PART2 = 0x21;
+    const byte FUNCTIONS_GET_PART2 = 0x22;
+
     // these settings will be initialised in connect()
     heatpumpSettings currentSettings {};
     heatpumpSettings wantedSettings {};
@@ -210,6 +214,8 @@ class HeatPump
     void createInfoPacket(byte *packet, byte packetType);
     int readPacket();
     void writePacket(byte *packet, int length);
+    void prepareInfoPacket(byte* packet, int length);
+    void prepareSetPacket(byte* packet, int length);
 
     // callbacks
     ON_CONNECT_CALLBACK_SIGNATURE {nullptr};
@@ -265,6 +271,7 @@ class HeatPump
     bool isConnected();
 
     // functions
+    // NOTE: These methods have been tested with a PVA (P-series air handler) unit and has not been tested with anything else. Use at your own risk.
     heatpumpFunctions getFunctions();
     bool setFunctions(heatpumpFunctions const& functions);
     

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -1,17 +1,14 @@
 /*
   HeatPump.h - Mitsubishi Heat Pump control library for Arduino
   Copyright (c) 2017 Al Betschart.  All right reserved.
-
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
   version 2.1 of the License, or (at your option) any later version.
-
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
   Lesser General Public License for more details.
-
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -80,6 +77,45 @@ struct heatpumpStatus {
   int compressorFrequency;
 };
 
+#define MAX_FUNCTION_CODE_COUNT 30
+
+struct heatpumpFunctionCodes {
+  bool valid[MAX_FUNCTION_CODE_COUNT];
+  int code[MAX_FUNCTION_CODE_COUNT];
+};
+
+class heatpumpFunctions  {
+  private:
+    byte raw[MAX_FUNCTION_CODE_COUNT];
+    bool _isValid1;
+    bool _isValid2;
+
+    int getCode(byte b);
+    int getValue(byte b);
+
+  public:
+    heatpumpFunctions();
+
+    bool isValid() const;
+    
+    // data must be 15 bytes
+    void setData1(byte* data);
+    void setData2(byte* data);
+    void getData1(byte* data) const;
+    void getData2(byte* data) const;
+    
+    void clear();
+
+    int getValue(int code);
+    bool setValue(int code, int value);
+
+    heatpumpFunctionCodes getAllCodes();   
+
+    bool operator==(const heatpumpFunctions& rhs);
+    bool operator!=(const heatpumpFunctions& rhs);
+
+};
+
 class HeatPump
 {
   private:
@@ -114,6 +150,7 @@ class HeatPump
     const int RCVD_PKT_UPDATE_SUCCESS  = 4;
     const int RCVD_PKT_STATUS          = 5;
     const int RCVD_PKT_TIMER           = 6;
+    const int RCVD_PKT_FUNCTIONS       = 7;
 
     const byte CONTROL_PACKET_1[5] = {0x01,    0x02,  0x04,  0x08, 0x10};
                                    //{"POWER","MODE","TEMP","FAN","VANE"};
@@ -146,6 +183,8 @@ class HeatPump
 
     // initialise to all off, then it will update shortly after connect;
     heatpumpStatus currentStatus {0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0};
+
+    heatpumpFunctions functions;
   
     HardwareSerial * _HardSerial {nullptr};
     unsigned long lastSend;
@@ -190,7 +229,8 @@ class HeatPump
     // general
     HeatPump();
     bool connect(HardwareSerial *serial);
-    bool connect(HardwareSerial *serial, int bitrate);
+    bool connect(HardwareSerial *serial, int rx, int tx);
+    bool connect(HardwareSerial *serial, int bitrate, int rx, int tx);
     bool update();
     void sync(byte packetType = PACKET_TYPE_DEFAULT);
     void enableExternalUpdate();
@@ -224,6 +264,10 @@ class HeatPump
     bool getOperating();
     bool isConnected();
 
+    // functions
+    heatpumpFunctions getFunctions();
+    bool setFunctions(heatpumpFunctions const& functions);
+    
     // helpers
     float FahrenheitToCelsius(int tempF);
     int CelsiusToFahrenheit(float tempC);


### PR DESCRIPTION
This is based on monitoring communication between MHK1 and an air handler (PVA) and some Mitsubishi technical documents.

References:
- https://www.mitsubishitechinfo.ca/sites/default/files/Installation_Manual_69-2426-01_0.pdf, page 6
- https://www.mitsubishitechinfo.ca/sites/default/files/IM_PVA_A12_42AA7_PA79D213H09.pdf, page 22
- https://www.mitsubishitechinfo.ca/sites/default/files/SH_PVA-A12_42AA7_201812.pdf, page 21

In order to read the current value of function codes MHK1 sends the following packets:
FC 42 01 30 10 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 5D
FC 42 01 30 10 22 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 5B

The following is returned by the unit:
FC 62 01 30 10 20 06 09 0D 11 16 18 3D 41 45 48 4C 50 54 58 00 8F
FC 62 01 30 10 22 1F 22 24 29 2E 31 36 38 5D 61 65 69 6D 72 00 75

In this PR I'm incorporating this functionality. Since the function codes seem to depend on the models I'm keeping the implementation generic and it is up to the caller to find out what each function code controls. 

I've also added support to connect to the heatpump using non-default serial pins, for people who use chips such as ESP32 that has multiple serial outputs.