### PR TITLE
Read all packets in buffer during sync and before update

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -158,6 +158,9 @@ bool HeatPump::update() {
 		    delay(10);
 	    }
 	    sync(RQST_PKT_SETTINGS);
+    } else {
+      // No auto update, but the next time we sync, fetch the updated settings first
+      infoMode = 0;
     }
 
     return true;

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -213,6 +213,7 @@ class HeatPump
     void createPacket(byte *packet, heatpumpSettings settings);
     void createInfoPacket(byte *packet, byte packetType);
     int readPacket();
+    void readAllPackets();
     void writePacket(byte *packet, int length);
     void prepareInfoPacket(byte* packet, int length);
     void prepareSetPacket(byte* packet, int length);


### PR DESCRIPTION
Currently we strictly read one packet each time `sync()` is called.
This means that if `writePacket()` is ever called twice in a row
before reading, a packet will be permanently buffered.

In cases where you expect to write a packet and receive a response
in the next packet, such as during `update()`, having buffered packets
guarantees you won't receive the correct packet next.

Changing `sync()` and `update()` to flush the serial buffer makes the
behavior much more robust and in my testing has always given me the
0x41 0x61 pair successfully when I call `update()`.

Closes #181 