### PR TITLE
Ignore external updates grace period

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -641,7 +641,7 @@ int HeatPump::readPacket() {
               }
 
               // if this is the first time we have synced with the heatpump, set wantedSettings to receivedSettings
-			  // hack: add grace period of a few seconds before respecting external changes
+              // hack: add grace period of a few seconds before respecting external changes
               if(firstRun || (autoUpdate && externalUpdate && millis() - lastWanted > AUTOUPDATE_GRACE_PERIOD_IGNORE_EXTERNAL_UPDATES_MS)) {
                 wantedSettings = currentSettings;
                 firstRun = false;

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -70,6 +70,7 @@ bool operator!=(const heatpumpTimers& lhs, const heatpumpTimers& rhs) {
 // Constructor /////////////////////////////////////////////////////////////////
 
 HeatPump::HeatPump() {
+  lastWanted = millis();
   lastSend = 0;
   infoMode = 0;
   lastRecv = millis() - (PACKET_SENT_INTERVAL_MS * 10);
@@ -226,6 +227,7 @@ bool HeatPump::getPowerSettingBool() {
 
 void HeatPump::setPowerSetting(bool setting) {
   wantedSettings.power = lookupByteMapIndex(POWER_MAP, 2, POWER_MAP[setting ? 1 : 0]) > -1 ? POWER_MAP[setting ? 1 : 0] : POWER_MAP[0];
+  lastWanted = millis();
 }
 
 const char* HeatPump::getPowerSetting() {
@@ -239,6 +241,7 @@ void HeatPump::setPowerSetting(const char* setting) {
   } else {
     wantedSettings.power = POWER_MAP[0];
   }
+  lastWanted = millis();
 }
 
 const char* HeatPump::getModeSetting() {
@@ -252,6 +255,7 @@ void HeatPump::setModeSetting(const char* setting) {
   } else {
     wantedSettings.mode = MODE_MAP[0];
   }
+  lastWanted = millis();
 }
 
 float HeatPump::getTemperature() {
@@ -268,6 +272,7 @@ void HeatPump::setTemperature(float setting) {
     setting = setting / 2;
     wantedSettings.temperature = setting < 10 ? 10 : (setting > 31 ? 31 : setting);
   }
+  lastWanted = millis();
 }
 
 void HeatPump::setRemoteTemperature(float setting) {
@@ -309,6 +314,7 @@ void HeatPump::setFanSpeed(const char* setting) {
   } else {
     wantedSettings.fan = FAN_MAP[0];
   }
+  lastWanted = millis();
 }
 
 const char* HeatPump::getVaneSetting() {
@@ -322,6 +328,7 @@ void HeatPump::setVaneSetting(const char* setting) {
   } else {
     wantedSettings.vane = VANE_MAP[0];
   }
+  lastWanted = millis();
 }
 
 const char* HeatPump::getWideVaneSetting() {
@@ -335,6 +342,7 @@ void HeatPump::setWideVaneSetting(const char* setting) {
   } else {
     wantedSettings.wideVane = WIDEVANE_MAP[0];
   }
+  lastWanted = millis();
 }
 
 bool HeatPump::getIseeBool() { //no setter yet
@@ -633,7 +641,8 @@ int HeatPump::readPacket() {
               }
 
               // if this is the first time we have synced with the heatpump, set wantedSettings to receivedSettings
-              if(firstRun || (autoUpdate && externalUpdate)) {
+			  // hack: add grace period of a few seconds before respecting external changes
+              if(firstRun || (autoUpdate && externalUpdate && millis() - lastWanted > AUTOUPDATE_GRACE_PERIOD_IGNORE_EXTERNAL_UPDATES_MS)) {
                 wantedSettings = currentSettings;
                 firstRun = false;
               }

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -122,7 +122,7 @@ class HeatPump
     static const int PACKET_SENT_INTERVAL_MS = 1000;
     static const int PACKET_INFO_INTERVAL_MS = 2000;
     static const int PACKET_TYPE_DEFAULT = 99;
-	static const int AUTOUPDATE_GRACE_PERIOD_IGNORE_EXTERNAL_UPDATES_MS = 30000;
+    static const int AUTOUPDATE_GRACE_PERIOD_IGNORE_EXTERNAL_UPDATES_MS = 30000;
 
     static const int CONNECT_LEN = 8;
     const byte CONNECT[CONNECT_LEN] = {0xfc, 0x5a, 0x01, 0x30, 0x02, 0xca, 0x01, 0xa8};
@@ -185,8 +185,8 @@ class HeatPump
     // these settings will be initialised in connect()
     heatpumpSettings currentSettings {};
     heatpumpSettings wantedSettings {};
-	// Hacks
-	unsigned long lastWanted;
+    // Hacks
+    unsigned long lastWanted;
 
     // initialise to all off, then it will update shortly after connect;
     heatpumpStatus currentStatus {0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0};

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -122,6 +122,7 @@ class HeatPump
     static const int PACKET_SENT_INTERVAL_MS = 1000;
     static const int PACKET_INFO_INTERVAL_MS = 2000;
     static const int PACKET_TYPE_DEFAULT = 99;
+	static const int AUTOUPDATE_GRACE_PERIOD_IGNORE_EXTERNAL_UPDATES_MS = 30000;
 
     static const int CONNECT_LEN = 8;
     const byte CONNECT[CONNECT_LEN] = {0xfc, 0x5a, 0x01, 0x30, 0x02, 0xca, 0x01, 0xa8};
@@ -184,6 +185,8 @@ class HeatPump
     // these settings will be initialised in connect()
     heatpumpSettings currentSettings {};
     heatpumpSettings wantedSettings {};
+	// Hacks
+	unsigned long lastWanted;
 
     // initialise to all off, then it will update shortly after connect;
     heatpumpStatus currentStatus {0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0};


### PR DESCRIPTION
As discussed in https://github.com/SwiCago/HeatPump/issues/192 there is a problem affecting users with external updates enabled - if an update() from heatpump library fails, external update will clobber that change, and therefore the library initiated change will never be applied (a dropped request)

The core logic here - any of these methods will prioritize the library and **trump external updates for 30 seconds**.

- `setPowerSetting`
- `setModeSetting`
- `setTemperature`
- `setFanSpeed`
- `setVaneSetting`
- `setWideVaneSetting`

This will ensure library initiated changes have enough time to be applied, before considering external updates done by someone manually controlling the thermostat, or any other mitsubishi controller.

In short, this gives a more consistent experience for those who have external updates enabled.