### PR TITLE
Fix missing UART pin when retry for ESP32. Not reset connected state when retry, make control more stable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(COMPONENT_SRCDIRS
+"src"
+)
+ 
+set(COMPONENT_ADD_INCLUDEDIRS
+"src"
+)
+ 
+set(COMPONENT_REQUIRES
+"arduino-esp32"
+)
+ 
+register_component()
+ 
+target_compile_definitions(${COMPONENT_TARGET} PUBLIC -DESP32)
+target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)  

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -106,15 +106,20 @@ bool HeatPump::connect(HardwareSerial *serial, int bitrate, int rx, int tx) {
     bitrate = 2400;
     retry = true;
   }
-  connected = false;
   if (rx >= 0 && tx >= 0) {
-#if defined(ESP32)    
+#if defined(ESP32)
+    rxPin = rx;
+    txPin = tx;        
     _HardSerial->begin(bitrate, SERIAL_8E1, rx, tx);
 #else
     _HardSerial->begin(bitrate, SERIAL_8E1);
 #endif    
   } else {
+#if defined(ESP32)      
+    _HardSerial->begin(bitrate, SERIAL_8E1, rxPin, txPin);
+#else
     _HardSerial->begin(bitrate, SERIAL_8E1);
+#endif
   }
   if(onConnectCallback) {
     onConnectCallback();
@@ -133,7 +138,8 @@ bool HeatPump::connect(HardwareSerial *serial, int bitrate, int rx, int tx) {
   if(packetType != RCVD_PKT_CONNECT_SUCCESS && retry){
 	  return connect(serial, 9600, rx, tx);
   }
-  return packetType == RCVD_PKT_CONNECT_SUCCESS;
+  connected = (packetType == RCVD_PKT_CONNECT_SUCCESS);
+  return connected;
   //}
 }
 

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -109,13 +109,13 @@ bool HeatPump::connect(HardwareSerial *serial, int bitrate, int rx, int tx) {
   if (rx >= 0 && tx >= 0) {
 #if defined(ESP32)
     rxPin = rx;
-    txPin = tx;        
+    txPin = tx;
     _HardSerial->begin(bitrate, SERIAL_8E1, rx, tx);
 #else
     _HardSerial->begin(bitrate, SERIAL_8E1);
-#endif    
+#endif
   } else {
-#if defined(ESP32)      
+#if defined(ESP32)
     _HardSerial->begin(bitrate, SERIAL_8E1, rxPin, txPin);
 #else
     _HardSerial->begin(bitrate, SERIAL_8E1);
@@ -125,8 +125,12 @@ bool HeatPump::connect(HardwareSerial *serial, int bitrate, int rx, int tx) {
     onConnectCallback();
   }
   
-  // settle before we start sending packets
+// settle before we start sending packets
+#if defined(ESP32)
+  delay(1000);
+#else
   delay(2000);
+#endif
 
   // send the CONNECT packet twice - need to copy the CONNECT packet locally
   byte packet[CONNECT_LEN];
@@ -136,7 +140,7 @@ bool HeatPump::connect(HardwareSerial *serial, int bitrate, int rx, int tx) {
   while(!canRead()) { delay(10); }
   int packetType = readPacket();
   if(packetType != RCVD_PKT_CONNECT_SUCCESS && retry){
-	  return connect(serial, 9600, rx, tx);
+	  return connect(serial, 9600, rxPin, txPin);
   }
   connected = (packetType == RCVD_PKT_CONNECT_SUCCESS);
   return connected;
@@ -637,7 +641,7 @@ int HeatPump::readPacket() {
               receivedSettings.fan         = lookupByteMapValue(FAN_MAP, FAN, 6, data[6]);
               receivedSettings.vane        = lookupByteMapValue(VANE_MAP, VANE, 7, data[7]);
               receivedSettings.wideVane    = lookupByteMapValue(WIDEVANE_MAP, WIDEVANE, 7, data[10] & 0x0F);
-		    wideVaneAdj = (data[10] & 0xF0) == 0x80 ? true : false;
+		      wideVaneAdj = (data[10] & 0xF0) == 0x80 ? true : false;
               
               if(settingsChangedCallback && receivedSettings != currentSettings) {
                 currentSettings = receivedSettings;

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -194,6 +194,8 @@ class HeatPump
     heatpumpFunctions functions;
   
     HardwareSerial * _HardSerial {nullptr};
+    int rxPin; // save rx pin for retry ESP32
+    int txPin; // save tx pin for retry ESP32
     unsigned long lastSend;
     bool waitForRead;
     int infoMode;


### PR DESCRIPTION
When code in https://github.com/SwiCago/HeatPump/blob/cea90c5ed48d24a904835f8918bd88cbc84cb1be/src/HeatPump.cpp#L175 call, connected state first reset to false even it is true before and blackout about 2 seconds after it online again, my logic check this state to send command to heat pump. So not reset it in the first time after the connection failed or timeout make it more stable.
Also when connect(NULL) call,  the rx, tx set for ESP32 become -1 and it fall back to default hardware pin, two variable store these pin in the first call fix the issue.