### PR TITLE
Fix slow sync when using IR or wall remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ hp.setSettings(settings);
 // OR individual settings
 // hp.setModeSetting("COOL");
 
+// hp.setFastSync(true); // enable fast sync mode, we only request RQST_PKT_SETTINGS, RQST_PKT_ROOM_TEMP and RQST_PKT_STATUS
 hp.update();
 ```
 

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -235,18 +235,15 @@ heatpumpSettings HeatPump::getSettings() {
   return currentSettings;
 }
 
-heatpumpSettings HeatPump::getWantedSettings()
-{
+heatpumpSettings HeatPump::getWantedSettings() {
   return wantedSettings;
 }
 
-unsigned long HeatPump::getLastWanted()
-{
+unsigned long HeatPump::getLastWanted() {
   return lastWanted;
 }
 
-void HeatPump::setFastSync(bool setting)
-{
+void HeatPump::setFastSync(bool setting) {
   fastSync = setting;
 }
 
@@ -558,12 +555,10 @@ void HeatPump::createInfoPacket(byte *packet, byte packetType) {
   } else {
     // request current infoMode, and increment for the next request
     packet[5] = INFOMODE[infoMode];
-    if (infoMode == (fastSync ? 2 : (INFOMODE_LEN - 1)))
-    { // if enable fastSync we only request RQST_PKT_SETTINGS, RQST_PKT_ROOM_TEMP and RQST_PKT_STATUS, so the sync will be 2x faster
+    // if enable fastSync we only request RQST_PKT_SETTINGS, RQST_PKT_ROOM_TEMP and RQST_PKT_STATUS, so the sync will be 2x faster
+    if (infoMode == (fastSync ? 2 : (INFOMODE_LEN - 1))) {
       infoMode = 0;
-    }
-    else
-    {
+    } else {
       infoMode++;
     }
   }

--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -235,6 +235,21 @@ heatpumpSettings HeatPump::getSettings() {
   return currentSettings;
 }
 
+heatpumpSettings HeatPump::getWantedSettings()
+{
+  return wantedSettings;
+}
+
+unsigned long HeatPump::getLastWanted()
+{
+  return lastWanted;
+}
+
+void HeatPump::setFastSync(bool setting)
+{
+  fastSync = setting;
+}
+
 bool HeatPump::isConnected() {
   return connected;
 }
@@ -543,9 +558,12 @@ void HeatPump::createInfoPacket(byte *packet, byte packetType) {
   } else {
     // request current infoMode, and increment for the next request
     packet[5] = INFOMODE[infoMode];
-    if(infoMode == (INFOMODE_LEN - 1)) {
+    if (infoMode == (fastSync ? 2 : (INFOMODE_LEN - 1)))
+    { // if enable fastSync we only request RQST_PKT_SETTINGS, RQST_PKT_ROOM_TEMP and RQST_PKT_STATUS, so the sync will be 2x faster
       infoMode = 0;
-    } else {
+    }
+    else
+    {
       infoMode++;
     }
   }

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -137,9 +137,9 @@ class HeatPump
     const byte INFOMODE[INFOMODE_LEN] = {
       0x02, // request a settings packet - RQST_PKT_SETTINGS
       0x03, // request the current room temp - RQST_PKT_ROOM_TEMP
+      0x06, // request status - RQST_PKT_STATUS
       0x04, // unknown
       0x05, // request the timers - RQST_PKT_TIMERS
-      0x06, // request status - RQST_PKT_STATUS
       0x09  // request standby mode (maybe?) RQST_PKT_STANDBY
     };
 
@@ -206,6 +206,7 @@ class HeatPump
     bool tempMode;
     bool externalUpdate;
     bool wideVaneAdj;
+    bool fastSync = false;
 
     const char* lookupByteMapValue(const char* valuesMap[], const byte byteMap[], int len, byte byteValue);
     int    lookupByteMapValue(const int valuesMap[], const byte byteMap[], int len, byte byteValue);
@@ -253,6 +254,8 @@ class HeatPump
 
     // settings
     heatpumpSettings getSettings();
+    // wanted settings
+    heatpumpSettings getWantedSettings();
     void setSettings(heatpumpSettings settings);
     void setPowerSetting(bool setting);
     bool getPowerSettingBool(); 
@@ -270,6 +273,9 @@ class HeatPump
     const char* getWideVaneSetting();
     void setWideVaneSetting(const char* setting);
     bool getIseeBool();
+    void setFastSync(bool setting);
+    // hacks
+    unsigned long getLastWanted();
 
     // status
     heatpumpStatus getStatus();


### PR DESCRIPTION
With this change and enable fast sync, time sync speed up by 2x.
Expose wantedSettings and lastWanted make mqtt control over Home Assistant more stable, see: https://github.com/dzungpv/mitsubishi2MQTT