### PR TITLE
add outdoorTemperature to heatpump status reports

### DIFF
--- a/examples/mitsubishi_heatpump_mqtt_esp8266_esp32/mitsubishi_heatpump_mqtt_esp8266_esp32.ino
+++ b/examples/mitsubishi_heatpump_mqtt_esp8266_esp32/mitsubishi_heatpump_mqtt_esp8266_esp32.ino
@@ -98,8 +98,9 @@ void hpStatusChanged(heatpumpStatus currentStatus) {
   const size_t bufferSizeInfo = JSON_OBJECT_SIZE(2);
   DynamicJsonDocument rootInfo(bufferSizeInfo);
 
-  rootInfo["roomTemperature"] = currentStatus.roomTemperature;
-  rootInfo["operating"]       = currentStatus.operating;
+  rootInfo["roomTemperature"]    = currentStatus.roomTemperature;
+  rootInfo["outdoorTemperature"] = currentStatus.outdoorTemperature;
+  rootInfo["operating"]          = currentStatus.operating;
 
   char bufferInfo[512];
   serializeJson(rootInfo, bufferInfo);

--- a/integrations/OpenHAB/mitsubishi_heatpump_mqtt_esp8266_template/mitsubishi_heatpump_mqtt_esp8266_template.ino
+++ b/integrations/OpenHAB/mitsubishi_heatpump_mqtt_esp8266_template/mitsubishi_heatpump_mqtt_esp8266_template.ino
@@ -84,8 +84,9 @@ void hpStatusChanged(heatpumpStatus currentStatus) {
   DynamicJsonBuffer jsonBufferInfo(bufferSizeInfo);
   
   JsonObject& rootInfo = jsonBufferInfo.createObject();
-  rootInfo["roomTemperature"] = (isCelsius) ? hp.getRoomTemperature() : hp.CelsiusToFahrenheit(hp.getRoomTemperature());
-  rootInfo["operating"]       = currentStatus.operating;
+  rootInfo["roomTemperature"]    = (isCelsius) ? hp.getRoomTemperature() : hp.CelsiusToFahrenheit(hp.getRoomTemperature());
+  rootInfo["outdoorTemperature"] = (isCelsius) ? hp.getOutdoorTemperature() : hp.CelsiusToFahrenheit(hp.getOutdoorTemperature());
+  rootInfo["operating"]          = currentStatus.operating;
   
   char bufferInfo[512];
   rootInfo.printTo(bufferInfo, sizeof(bufferInfo));

--- a/keywords.txt
+++ b/keywords.txt
@@ -36,6 +36,7 @@ getIseeBool	KEYWORD2
 
 getStatus	KEYWORD2
 getRoomTemperature	KEYWORD2
+getOutdoorTemperature	KEYWORD2
 getOperating	KEYWORD2
 
 FahrenheitToCelsius	KEYWORD2

--- a/src/HeatPump.h
+++ b/src/HeatPump.h
@@ -72,6 +72,7 @@ bool operator!=(const heatpumpTimers& lhs, const heatpumpTimers& rhs);
 
 struct heatpumpStatus {
   float roomTemperature;
+  float outdoorTemperature;
   bool operating; // if true, the heatpump is operating to reach the desired temperature
   heatpumpTimers timers;
   int compressorFrequency;
@@ -189,7 +190,7 @@ class HeatPump
     unsigned long lastWanted;
 
     // initialise to all off, then it will update shortly after connect;
-    heatpumpStatus currentStatus {0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0};
+    heatpumpStatus currentStatus {0, 0, false, {TIMER_MODE_MAP[0], 0, 0, 0, 0}, 0};
 
     heatpumpFunctions functions;
   
@@ -274,6 +275,7 @@ class HeatPump
     // status
     heatpumpStatus getStatus();
     float getRoomTemperature();
+    float getOutdoorTemperature();
     bool getOperating();
     bool isConnected();
 


### PR DESCRIPTION
based on documented room/remote temp from [here](https://github.com/Sammy1Am/mitsubishi-uart/wiki/%280x62%29-Get-Response#type-0x03---get-roomremote-temp) and tested on my Mitsubishi AP50 high wall unit.