### PR TITLE
Simply remote temperature calculation

### DIFF
--- a/src/HeatPump.cpp
+++ b/src/HeatPump.cpp
@@ -324,11 +324,8 @@ void HeatPump::setRemoteTemperature(float setting) {
     packet[6] = 0x01;
     setting = setting * 2;
     setting = round(setting);
-    setting = setting / 2;
-    float temp1 = 3 + ((setting - 10) * 2);
-    packet[7] = (int)temp1;
-    float temp2 = (setting * 2) + 128;
-    packet[8] = (int)temp2;
+    packet[7] = (byte)(setting - 16);
+    packet[8] = (byte)(setting + 128);
   }
   else {
     packet[6] = 0x00;


### PR DESCRIPTION
This PR simplifies and corrects calculation of temperature values in setRemoteTemperature(float setting):

The original values calculated are:

    packet[7] = 3 + ((round(setting * 2) / 2) - 10) * 2
    packet[8] = round(setting * 2) / 2 * 2 + 128

which can be simplified to:

    packet[7] = round(setting * 2) - 17
    packet[8] = round(setting * 2) + 128

The heat pump ignores the value in packet[7] when packet[8] is set. Leaving packet[8] unset shows an error of 0.5°C between reported room temperature and sent remote temperature. Therefore the correct value should be:

    packet[7] = round(setting * 2) - 16
